### PR TITLE
add aiortc

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5880,6 +5880,22 @@ python3-aiohttp-cors:
   fedora: [python-aiohttp-cors]
   gentoo: [dev-python/aiohttp-cors]
   ubuntu: [python3-aiohttp-cors]
+python3-aiortc-pip:
+  debian:
+    pip:
+      packages: [aiortc]
+  fedora:
+    pip:
+      packages: [aiortc]
+  gentoo:
+    pip:
+      packages: [aiortc]
+  osx:
+    pip:
+      packages: [aiortc]
+  ubuntu:
+    pip:
+      packages: [aiortc]
 python3-albumentations-pip:
   debian:
     pip:


### PR DESCRIPTION
Yeah, I really feel like removing the template pull request. BTW I already tested this. Some point in the future we need a Continuous Integration System.

BTW, `aiortc` from <https://github.com/aiortc/aiortc> is pretty much the only way in Python to WebRTC. Its somehow surprisingly stable and performant (despite being written in Python) and supports DataChannels (the main part we are using here; Until [WebTransport](https://www.w3.org/TR/webtransport/) is mainstream, this is the only UDP method for sending data to a browser).