### PR TITLE
add norfair

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7347,6 +7347,17 @@ python3-nlopt:
     '*': [python3-nlopt]
     bionic: null
     xenial: null
+python3-norfair-pip:
+  debian:
+    pip: [norfair]
+  fedora:
+    pip: [norfair]
+  gentoo:
+    pip: [norfair]
+  osx:
+    pip: [norfair]
+  ubuntu:
+    pip: [norfair]
 python3-nose:
   arch: [python-nose]
   debian: [python3-nose]


### PR DESCRIPTION
[`norfair`](https://github.com/tryolabs/norfair) is somehow the only general framework for trackers that exist as of now. Given its modular and easily customizable nature, along with being the only one developer-friendly enough to be installed via `pip`, it is pretty much necessary for our Motion Object Tracking (MOT) needs.